### PR TITLE
[#47] - Agregar helpers para el uso de MediaQueries y Eliminar imagien del login en MediaQuerie 

### DIFF
--- a/src/atoms/CoffeeBanner.jsx
+++ b/src/atoms/CoffeeBanner.jsx
@@ -3,12 +3,20 @@ import styled from '@emotion/styled';
 
 import H1 from '../atoms/H1';
 import IconCoffee from '../image/IconCoffee.svg';
+import {mediaMinwidth} from '../styles/utils/helpers';
 
 const Logo = styled.div`
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
+  align-items: center;
   gap: 1rem;
+  ${H1} {
+    font-size: 2rem;
+    line-height: 1.75rem;
+    ${mediaMinwidth.md} {
+      line-height: 3.5rem;
+      font-size: 2.8rem;
+    }
+  }
 `;
 
 const LogoIcon = styled.img`

--- a/src/molecules/Header.jsx
+++ b/src/molecules/Header.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import {CoffeeBanner} from '../atoms/CoffeeBanner';
+import {mediaMinwidth} from '../styles/utils/helpers';
 
 import {TopMenu} from './TopMenu';
 
@@ -9,7 +10,14 @@ const Container = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 2rem;
+  flex-direction: column;
+  padding: 0 1.6rem;
+  ${mediaMinwidth.sm} {
+    flex-direction: row;
+  }
+  ${mediaMinwidth.md} {
+    padding: 0 2rem;
+  }
 `;
 
 export const Header = () => {

--- a/src/molecules/TopMenu.jsx
+++ b/src/molecules/TopMenu.jsx
@@ -2,18 +2,29 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import H3 from '../atoms/H3';
+import {mediaMinwidth} from '../styles/utils/helpers';
 
 const Nav = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 4rem;
+  margin-top: 1rem;
+  ${mediaMinwidth.md} {
+    margin-top: 0;
+  }
 `;
 
 const NavItem = styled.a`
   color: 'inherit';
   text-decoration: none;
   cursor: pointer;
+  ${H3} {
+    font-size: 1.8rem;
+    ${mediaMinwidth.lg} {
+      font-size: 2rem;
+    }
+  }
 `;
 
 export const TopMenu = () => {

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -6,9 +6,14 @@ import {Header} from '../molecules/Header';
 import {LoginForm} from '../molecules/LoginForm';
 import HomeImage from '../image/homeImage.svg';
 import BackgroundCoffee from '../image/backgroundCoffee.svg';
+import {mediaMinwidth} from '../styles/utils/helpers';
 
 const Image = styled.img`
+  display: none;
   width: 49rem;
+  ${mediaMinwidth.lg} {
+    display: block;
+  }
 `;
 
 const LayoutLogin = styled.div`

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -10,8 +10,9 @@ import {mediaMinwidth} from '../styles/utils/helpers';
 
 const Image = styled.img`
   display: none;
-  width: 49rem;
-  ${mediaMinwidth.lg} {
+  width: 50%;
+  max-width: 49rem;
+  ${mediaMinwidth.md} {
     display: block;
   }
 `;

--- a/src/styles/utils/helpers.js
+++ b/src/styles/utils/helpers.js
@@ -1,0 +1,20 @@
+export const breakpoints = [
+  {key: 'xs', value: 0},
+  {key: 'sm', value: 576},
+  {key: 'md', value: 768},
+  {key: 'lg', value: 992},
+  {key: 'xl', value: 1200},
+  {key: 'xxl', value: 1400},
+];
+
+export const mediaMinwidth = breakpoints.reduce((minObject, {key, value}) => {
+  minObject[key] = `@media (min-width: ${value}px)`;
+
+  return minObject;
+}, {});
+
+export const mediaMaxwidth = breakpoints.reduce((maxObject, {key, value}) => {
+  maxObject[key] = `@media (max-width: ${value}px)`;
+
+  return maxObject;
+}, {});

--- a/src/styles/utils/helpers.js
+++ b/src/styles/utils/helpers.js
@@ -14,7 +14,7 @@ export const mediaMinwidth = breakpoints.reduce((minObject, {key, value}) => {
 }, {});
 
 export const mediaMaxwidth = breakpoints.reduce((maxObject, {key, value}) => {
-  maxObject[key] = `@media (max-width: ${value}px)`;
+  maxObject[key] = `@media (max-width: ${value - 0.2}px)`;
 
   return maxObject;
 }, {});


### PR DESCRIPTION
## Descripción

### MediaQueries dinámicos
Tomando de referencia la documentación de Emotion sobre las MediaQueries
- https://emotion.sh/docs/media-queries

Se implementaron dos helpers `mediaMinwidth` y `mediaMaxwidth`. De esta manera pueden ser reutilizados de para futuras -implementaciones.
-  **xs**  -> 0
-  **sm** -> 576
-  **md** ->768
-  **lg** -> 992
-  **xl** -> 1200
-  **xxl** -> 1400

Donde la salida de `mediaMinwidth.sm` sería `@media (min-width: 576px)`
Donde la salida de `mediaMinwidth.sm` sería `@media (min-width: 575.98px)`
```js
const Image = styled.img`
  display: none;
  width: 49rem;
  ${mediaMinwidth.lg} {
    display: block;
  }
`;
``` 
### Screens
#### Movil
![image](https://github.com/user-attachments/assets/6c77d629-db97-4712-93bd-8bd7315f39a6)
#### Tablet
![image](https://github.com/user-attachments/assets/7d43bf63-3ed7-40dc-8214-565a988a8c88)
#### Deskopt
![image](https://github.com/user-attachments/assets/27856702-f5cd-4062-b190-bd7e5e964a9c)

## Comentarios:
### `navbar`
- El componente de `navbar` seria recomendable su propio issue para agregar un menu de haburguesa.

