### PR TITLE
Fix p child of p

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "editor.bracketPairColorization.enabled": true,
   "editor.guides.bracketPairs": "active"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Proyecto react creado con vitejs.
 ## Intrucciones
 
 - Clonar el repo
-- Ejecutar *npm install* dentro del folder del repo clonado
+- Ejecutar *npm ci* dentro del folder del repo clonado
 - Instalar la extensión VSCode: ESLint.
 - También es recomendable tener seteado VSCode para formatear el código al grabar.
 

--- a/src/molecules/HeadearPurchaseReceipt.jsx
+++ b/src/molecules/HeadearPurchaseReceipt.jsx
@@ -8,7 +8,7 @@ const HeaderOneDouble = styled.h1`
 
 const BlockLeft = styled.p`
   font-size: 2rem;
-  > p {
+  > span {
     margin: 1rem 0;
   }
 `;
@@ -29,8 +29,9 @@ export const HeadearPurchaseReceipt = ({paymentDate, paymentHour, paymentNumber}
       <HeaderOneDouble>Recibo</HeaderOneDouble>
       <FlexContainer>
         <BlockLeft>
-          <p>{paymentDate}</p>
-          <p>{paymentHour}</p>
+          <span>{paymentDate}</span>
+          <br />
+          <span>{paymentHour}</span>
         </BlockLeft>
         <BlockRight>Orden No. {paymentNumber}</BlockRight>
       </FlexContainer>


### PR DESCRIPTION
In the code ... molecule/HeaderPurchaseReceipt.jsx

```
        <BlockLeft>
          <p>{paymentDate}</p>
          <p>{paymentHour}</p>
        </BlockLeft>
```

Blockleft is a p element. So that fires a console warning about to have`<p> child of <p>`. 